### PR TITLE
Make tox pass

### DIFF
--- a/retox/__main__.py
+++ b/retox/__main__.py
@@ -111,5 +111,6 @@ def get_hashes(path, ignore={'.pyc'}):
                     out[os.path.join(root, file)] = pytime
     return out
 
+
 if __name__ == '__main__':
     main(sys.argv)

--- a/retox/log.py
+++ b/retox/log.py
@@ -57,6 +57,7 @@ class RetoxLogging(object):
     def addHandler(self, handler):
         self.logger.addHandler(handler)
 
+
 logging.basicConfig(level=logging.ERROR)
 
 retox_log = RetoxLogging()

--- a/retox/reporter.py
+++ b/retox/reporter.py
@@ -42,6 +42,10 @@ class RetoxReporter(tox.session.Reporter):
         # Override default reporter functionality
         self.tw = FakeTerminalWriter()
 
+    @classmethod
+    def set_env_frames(cls, env_frames):
+        cls.env_frames = env_frames
+
     def _loopreport(self):
         '''
         Loop over the report progress

--- a/retox/reporter.py
+++ b/retox/reporter.py
@@ -52,8 +52,8 @@ class RetoxReporter(tox.session.Reporter):
             for action in self.session._actions:
                 for popen in action._popenlist:
                     if popen.poll() is None:
-                        l = ac2popenlist.setdefault(action.activity, [])
-                        l.append(popen)
+                        lst = ac2popenlist.setdefault(action.activity, [])
+                        lst.append(popen)
                 if not action._popenlist and action in self._actionmayfinish:
                     super(RetoxReporter, self).logaction_finish(action)
                     self._actionmayfinish.remove(action)

--- a/retox/service.py
+++ b/retox/service.py
@@ -130,9 +130,9 @@ class Resources(object):
                 if spec not in self._spec2thread:
                     t = self._pool.spawn(self._dispatchprovider, spec)
                     self._spec2thread[spec] = t
-        l = []
+        lst = []
         for spec in specs:
             if spec not in self._resources:
                 self._spec2thread[spec].wait()
-            l.append(self._resources[spec])
-        return l
+            lst.append(self._resources[spec])
+        return lst

--- a/retox/service.py
+++ b/retox/service.py
@@ -22,7 +22,7 @@ class RetoxService(object):
         self._sdistpath = None
 
         RetoxReporter.screen = screen
-        RetoxReporter.env_frames = env_frames
+        RetoxReporter.set_env_frames(env_frames)
 
         self.screen = screen
 

--- a/retox/ui.py
+++ b/retox/ui.py
@@ -1,7 +1,5 @@
 # -*- coding: utf-8 -*-
 
-import sys
-
 import asciimatics.widgets as widgets
 from asciimatics.screen import Screen
 from asciimatics.scene import Scene

--- a/test/test_nothing.py
+++ b/test/test_nothing.py
@@ -3,4 +3,4 @@ import unittest
 
 class TestNothing(unittest.TestCase):
     def test_nothing(self):
-        assert 1 == 2
+        assert 1 == 1

--- a/tox.ini
+++ b/tox.ini
@@ -1,6 +1,11 @@
 [tox]
 envlist = py27, py35, py36, lint, pylint
 
+[travis]
+python =
+  2.7: py27
+  3.6: py36, lint, pylint
+
 [testenv]
 deps = pytest
        six

--- a/tox.ini
+++ b/tox.ini
@@ -12,7 +12,7 @@ commands = python -m pytest test/
 [testenv:pylint]
 deps = pylint
 
-commands = pylint -E --disable=unsubscriptable-object --rcfile=./.pylintrc retox/
+commands = pylint -E --rcfile=./.pylintrc retox/
 
 [testenv:lint]
 deps = flake8

--- a/tox.ini
+++ b/tox.ini
@@ -12,8 +12,8 @@ commands = python -m pytest test/
 [testenv:pylint]
 deps = pylint
 
-commands = pylint -E --rcfile=./.pylintrc retox/
+commands = pylint -E --disable=unsubscriptable-object --rcfile=./.pylintrc retox/
 
 [testenv:lint]
-deps = pep8
+deps = flake8
 commands = flake8 --ignore=E402 --max-line-length=100 retox/

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = py27, py36, lint, pylint
+envlist = py27, py35, py36, lint, pylint
 
 [testenv]
 deps = pytest


### PR DESCRIPTION
https://travis-ci.org/bstpierre/retox/builds/320265084

This removes the intentional failure in the unit test and has tox passing all the checks.

I'm not really a fan of just disabling the pylint error, but wasn't sure about adding this fix to this PR:

```
diff --git a/retox/reporter.py b/retox/reporter.py
index 8363a83..55e6f16 100644
--- a/retox/reporter.py
+++ b/retox/reporter.py
@@ -42,6 +42,10 @@ class RetoxReporter(tox.session.Reporter):
         # Override default reporter functionality
         self.tw = FakeTerminalWriter()
 
+    @classmethod
+    def set_env_frames(cls, env_frames):
+        cls.env_frames = env_frames
+
     def _loopreport(self):
         '''
         Loop over the report progress
diff --git a/retox/service.py b/retox/service.py
index f588dfb..8104706 100644
--- a/retox/service.py
+++ b/retox/service.py
@@ -22,7 +22,7 @@ class RetoxService(object):
         self._sdistpath = None
 
         RetoxReporter.screen = screen
-        RetoxReporter.env_frames = env_frames
+        RetoxReporter.set_env_frames(env_frames)
 
         self.screen = screen
 ```

If you'd rather have that, I can commit this change.