### PR TITLE
Add --exclude argument

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -57,6 +57,15 @@ Retox can watch one or many directories for file changes and re-run the tox envi
 
     retox -w my_project_folder -w my_test_folder
 
+Excluding paths
+---------------
+
+Retox will ignore files matching a given regex:
+
+.. code-block:: bash
+
+    retox -w my_project_folder --exclude='.*\.(swp|pyc)$'
+
 Tox support
 -----------
 

--- a/retox/path.py
+++ b/retox/path.py
@@ -1,0 +1,8 @@
+# -*- coding: utf-8 -*-
+
+# Provide pathlib.Path here, using backported pathlib2 if needed.
+try:
+    from pathlib import Path
+    Path().expanduser()
+except (ImportError, AttributeError):
+    from pathlib2 import Path

--- a/retox/ui.py
+++ b/retox/ui.py
@@ -102,6 +102,11 @@ class RetoxFrame(widgets.Frame, RetoxRefreshMixin):
             self._watch_label = widgets.Label('Watching : %s  ' % ', '.join(args.option.watch))
             header_layout.add_widget(self._watch_label)
 
+        if args.option.exclude:
+            self._exclude_label = widgets.Label(
+                'Excluding : %s  ' % args.option.exclude)
+            header_layout.add_widget(self._exclude_label)
+
         self._commands_label = widgets.Label('Commands : (q) quit (b) build')
         header_layout.add_widget(self._commands_label)
         self.fix()

--- a/setup.py
+++ b/setup.py
@@ -12,7 +12,9 @@ requirements = [
     'tox==2.9.1',
     'eventlet==0.21.0',
     'asciimatics==1.9.0',
+    'pathlib2==2.3.0',
 ]
+
 
 def main():
     setup(
@@ -38,7 +40,9 @@ def main():
         packages=['retox', ],
         install_requires=[requirements],
         entry_points={'console_scripts': 'retox=retox.__main__:main',
-                      'tox': ['proclimit = retox.proclimit', 'watch = retox.watch']},
+                      'tox': ['exclude = retox.exclude',
+                              'proclimit = retox.proclimit',
+                              'watch = retox.watch']},
     )
 
 if __name__ == '__main__':

--- a/test/test_nothing.py
+++ b/test/test_nothing.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
 
 
-def test_nothing(self):
+def test_nothing():
     assert 1 == 1

--- a/test/test_watcher.py
+++ b/test/test_watcher.py
@@ -6,6 +6,7 @@ import argparse
 import os
 
 from retox.__main__ import get_hashes
+from retox.path import Path
 import retox.watch
 
 
@@ -39,6 +40,29 @@ def test_get_simple_hashes_timestamps():
 
     os_time = os.path.getmtime('test/test_watch/file1.py')
     assert hashes['test/test_watch/file1.py'] == os_time
+
+
+def test_hashes_dont_include_dirs():
+    files = get_hashes('test/')
+    paths = (Path(f) for f in files)
+    assert not any(p.is_dir() for p in paths)
+
+
+def test_get_excluded_hashes():
+    '''
+    Test that the hash method excludes files properly.
+    '''
+    files = get_hashes('test/', exclude='.*watch.*').keys()
+
+    # This file should be excluded because it matches the regex.
+    assert 'test/test_watcher.py' not in files
+
+    # This directory is excluded, so nothing under it should be present.
+    assert 'test/test_watch/file1.py' not in files
+    assert 'test/test_watch/sub/file2.py' not in files
+
+    # And we of course should still see (for example) test_log.py.
+    assert 'test/test_log.py' in files
 
 
 def test_multiple_watch_args():

--- a/tox.ini
+++ b/tox.ini
@@ -11,6 +11,7 @@ deps = pytest
        six
        mock
        codecov
+       pathlib2
        pytest-cov
 setenv =
     PYTHONPATH = {toxinidir}:{toxinidir}/retox


### PR DESCRIPTION
This adds an `--exclude=REGEX` command line option. Paths matching the
regex will be excluded. See #11.

Also:

- Show exclusion regex in the ui.
- Use pathlib to walk the watch trees instead of os.walk.

Notes:

- This matches against the entire file path, not just the filename. This seemed to make the most sense to me as I was working with it.
- This uses `re.match` which means that the regex is implicitly against the start of the string. It might be more usable to use `re.search`?
- I can run `retox -w . --exclude='(^\.tox|\.git|\.cache|\.coverage|\.retox\.json|retox\.log|__pycache__|.*\.(swp|pyc)$)' -e py35` and it behaves mostly as-expected. I say "mostly" only because I see a double-run when I run `tox` manually. Need to track this down, but I suspect it's just something missing from the regex.
- I'd be willing to add another test that exercises the path through main when the infrastructure in https://github.com/tonybaloney/retox/pull/12 lands.